### PR TITLE
Doxygen: stop producing LaTeX.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1645,7 +1645,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/Makefile.am
+++ b/Makefile.am
@@ -236,8 +236,9 @@ dist-rpm: dist-gzip
 	echo "RPM build finished";						\
 	#end of dist-rpm
 
-doxygen:
-	doxygen && cd doc/doxygen/latex && make
+.PHONY: doxygen
+doxygen: Doxyfile
+	doxygen
 
 test: all
 	$(top_builddir)/src/test/test

--- a/changes/ticket32099
+++ b/changes/ticket32099
@@ -1,0 +1,4 @@
+  o Removed features:
+    - Our Doxygen configuration no longer generates LaTeX output.  The
+      reference manual produced by doing this was over 4000 pages long,
+      and generally unusable.  Closes ticket 32099.


### PR DESCRIPTION
Running doxygen with latex gave us all manner of unicode issues,
slowed down the "make doxygen" target by a lot, and added several
latex dependencies... all to produce a 4000-page reference manual
which is probably not what anybody wanted.

Closes ticket 32099.